### PR TITLE
Support page titles in styleguide

### DIFF
--- a/core/templates/styleguide/component-group.pug
+++ b/core/templates/styleguide/component-group.pug
@@ -4,6 +4,7 @@ include ../mixins/sample
 
 block append pageVariables
     - var htmlClass = config.ui && config.ui.dark ? 'br-styleguide br-styleguide--dark' : 'br-styleguide'
+    - var moduleTitle = componentGroup.docs && componentGroup.docs.attributes.title || componentGroup.group.id
 
 block body
 
@@ -11,10 +12,8 @@ block body
         include ../includes/styleguide-nav
 
         .br-styleguide-content
-            if !componentGroup.docs
-                h1.br-componentgroup-header= componentGroup.group.id
-            else
-                h1.br-componentgroup-header= componentGroup.docs.attributes.title || componentGroup.group.id
+            h1.br-componentgroup-header= moduleTitle
+            if componentGroup.docs
                 .br-content
                     != componentGroup.docs.body
 

--- a/core/templates/styleguide/component-group.pug
+++ b/core/templates/styleguide/component-group.pug
@@ -2,9 +2,12 @@ extends ../../../content/templates/_layouts/master
 
 include ../mixins/sample
 
+
+
 block append pageVariables
     - var htmlClass = config.ui && config.ui.dark ? 'br-styleguide br-styleguide--dark' : 'br-styleguide'
-    - var moduleTitle = componentGroup.docs && componentGroup.docs.attributes.title || componentGroup.group.id
+    - var pageTitle = componentGroup.docs && componentGroup.docs.attributes.title || componentGroup.group.id
+    - var moduleTitle = pageTitle + '- Styleguide'
 
 block body
 
@@ -12,7 +15,7 @@ block body
         include ../includes/styleguide-nav
 
         .br-styleguide-content
-            h1.br-componentgroup-header= moduleTitle
+            h1.br-componentgroup-header= pageTitle
             if componentGroup.docs
                 .br-content
                     != componentGroup.docs.body

--- a/core/templates/styleguide/doc.pug
+++ b/core/templates/styleguide/doc.pug
@@ -2,7 +2,7 @@ extends ../../../content/templates/_layouts/master
 
 block append pageVariables
     - var htmlClass = config.ui && config.ui.dark ? 'br-styleguide br-styleguide--dark' : 'br-styleguide'
-    - var moduleTitle = doc.attributes.title
+    - var moduleTitle = doc.attributes.title + '- Styleguide'
 
 block body
 

--- a/core/templates/styleguide/doc.pug
+++ b/core/templates/styleguide/doc.pug
@@ -2,6 +2,7 @@ extends ../../../content/templates/_layouts/master
 
 block append pageVariables
     - var htmlClass = config.ui && config.ui.dark ? 'br-styleguide br-styleguide--dark' : 'br-styleguide'
+    - var moduleTitle = doc.attributes.title
 
 block body
 


### PR DESCRIPTION
@Wolfr  here is an initial fix for #195 

I say initial because I think I might need to work it a little bit more, but not sure.

Right now this adds supports to inject a <title> for styleguides pages, but the only thing I noticed is that for custom component styleguide, I didn't find an existing way to define a title, it uses the filename. 

If I create a example.md in the same folder as example.pug file with 

```
---
title: My component
---
```

This just rename the component title, but not the component-group top level page, you can also see on the sidebar that it is the filename that is displayed.

Is there a way I missed , and if not, should I add a way to be able to define this "component-group" title ? 

