### PR TITLE
Page state display enhancement

### DIFF
--- a/core/discovery/pages.js
+++ b/core/discovery/pages.js
@@ -34,6 +34,13 @@ function addPageInfo(page) {
   return page;
 }
 
+// Format to a not technical friendly label
+// eg: form--error -> "Error"
+function formatPageStateLabel(stateName) {
+  var stateLabel = stateName.split("--")[1].split("-").join(" ");
+  return stateLabel.substr(0,1).toUpperCase() + stateLabel.substr(1);
+}
+
 function movePageStatesToParentPage(obj, index, collection) {
   if (!obj) {
     return;
@@ -42,6 +49,10 @@ function movePageStatesToParentPage(obj, index, collection) {
   if (obj.name.includes('--')) {
     const parentStateName = obj.name.split('--')[0];
     const parentState = collection.find(obj => obj.name === parentStateName);
+
+    // Format to a not technical friendly label
+    // eg: form--error -> "Error"
+    obj.label = formatPageStateLabel(obj.name)
 
     // Add the state to the parent page
     if (!parentState.states) {

--- a/core/discovery/pages.js
+++ b/core/discovery/pages.js
@@ -8,12 +8,12 @@ const paths = require('../paths');
 const TEMPLATES_BASE_DIRECTORY = paths.content.templates.path;
 const TEMPLATES_MODULE_DIRECTORY = paths.content.templates.modulesPath;
 
-function mapChildren(children) {
+function mapChildren(children, parent) {
   children = children.map((obj) => {
-    obj = addPageInfo(obj);
+    obj = addPageInfo(obj, parent);
 
     if (obj.children) {
-      mapChildren(obj.children);
+      mapChildren(obj.children, obj);
     }
 
     return obj;
@@ -22,10 +22,14 @@ function mapChildren(children) {
   return _.sortBy(children, 'type');
 }
 
-function addPageInfo(page) {
+function addPageInfo(page, parent) {
   page.href = '/' + page.path.replace('.pug', '.html');
   page.name = page.name.replace('.pug', '');
   page.id = page.path.replace('.pug', '');
+  // Copy array
+  page.parents = parent.parents.slice()
+  // Push current
+  page.parents.push(page.name);
 
   if (page.href === '') {
     page.href = '/';
@@ -71,10 +75,12 @@ function discover() {
   const pagesAndFoldersSortedByType = _.chain(dirTree.directoryTree(TEMPLATES_BASE_DIRECTORY, ['.pug']).children)
     .filter(obj => obj.path.charAt(0) !== '_')
     .map(obj => {
-      obj = addPageInfo(obj);
+      // Root item
+      obj.parents = []
+      obj = addPageInfo(obj, obj);
 
       if (obj.children) {
-        obj.children = mapChildren(obj.children);
+        obj.children = mapChildren(obj.children, obj);
       }
 
       return obj;

--- a/core/templates/includes/prototype-nav.pug
+++ b/core/templates/includes/prototype-nav.pug
@@ -24,11 +24,10 @@ include ../mixins/render-page-tree
                 - var basePagePath = basePage.path.replace('.pug', '');
                 - var isBasePageActive = pathname === basePagePath;
 
-                li: a(href=basePage.href, class=isBasePageActive ? 'br-bordered-list__link--active' : null)
-                    = basePage.name
-
+                li: a(href=basePage.href, class=isBasePageActive ? 'br-bordered-list__link--active' : null) Base page
+                
                 each state in basePage.states
                     - var statePagePath = state.path.replace('.pug', '');
                     - var isStatePageActive = pathname === statePagePath;
                     li: a(href=state.href, class=isStatePageActive ? 'br-bordered-list__link--active' : null)
-                        = state.name
+                        = state.label

--- a/core/templates/includes/prototype-nav.pug
+++ b/core/templates/includes/prototype-nav.pug
@@ -18,14 +18,15 @@ include ../mixins/render-page-tree
         +renderPageTree
 
     if basePage && basePage.states
+        - var basePageParentsLabel = basePage.parents.join(" > ")
         .br-prototype-page-states
-            h3.br-prototype-nav-main-heading Page states
+            h3.br-prototype-nav-main-heading Page states for #{basePageParentsLabel}
             ul.br-bordered-list
                 - var basePagePath = basePage.path.replace('.pug', '');
                 - var isBasePageActive = pathname === basePagePath;
 
                 li: a(href=basePage.href, class=isBasePageActive ? 'br-bordered-list__link--active' : null) Base page
-                
+
                 each state in basePage.states
                     - var statePagePath = state.path.replace('.pug', '');
                     - var isStatePageActive = pathname === statePagePath;


### PR DESCRIPTION
Related issue: #181 

I have a first implem of this, I'm inferring the name of the states from the CSS class directly:

- get the part after the "--" 
- replace any "-" with a space
- capitalize the first letter

Example

> form--error => "Error"
> form--error-bla => "Error bla"

I have also added the logic to be able to display the breadcrumb that lead to that particular component as you specified

> module > form-example

it might need more love on the styling part, and also please test it on more deep path, it should work but it hasn't been tested

![screen shot 2018-05-24 at 16 58 46](https://user-images.githubusercontent.com/533590/40515640-fc8ee9c2-5f83-11e8-8d9e-565640f84b12.png)

