### PR TITLE
Auto import icon-font scss if enabled

### DIFF
--- a/content/scss/main.scss
+++ b/content/scss/main.scss
@@ -1,8 +1,3 @@
 // Start your CSS here
 // Set a path to colors in bedrock.config.js 
 @import "settings.colors";
-
-// Uncomment this line if you use an icon font
-// Feel free to delete if you are not using an icon font
-
-// @import "settings/icon-font";

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "js-beautify": "^1.5.10",
     "lodash": "^3.10.1",
     "marked": "^0.3.9",
+    "merge2": "^1.2.2",
     "mkdirp": "^0.5.1",
     "moment": "^2.20.1",
     "node-notifier": "^4.3.1",


### PR DESCRIPTION
Continued work of this PR: https://github.com/usebedrock/bedrock/pull/207

In my opinion doesn't need any documentation update, it just improve a bit the icon-font setup

needs an npm install as it brings a new package to merge gulp streams

cc @Wolfr 