### PR TITLE
[Ready for testing] Fix tree open/close states of modules

### DIFF
--- a/core/js/prototype-nav.js
+++ b/core/js/prototype-nav.js
@@ -28,7 +28,6 @@ try {
 $prototypeNav
   .find('.br-tree-dir-title')
   .each(function () {
-    let randomId = Math.floor(Math.random() * 1000)
     let moduleIds = $(this)
       .parentsUntil('.br-bordered-list')
       .find('.br-tree-dir-title')
@@ -40,7 +39,7 @@ $prototypeNav
     const indexOfClickedModule = moduleIds.findIndex(e => e === $(this).text());
     moduleIds = moduleIds.splice(0, indexOfClickedModule + 1);
 
-    $(this).attr('id', moduleIds.join('-') + randomId);
+    $(this).attr('id', moduleIds.join('-'));
   });
 
 /**

--- a/core/js/prototype-nav.js
+++ b/core/js/prototype-nav.js
@@ -54,7 +54,9 @@ function closeModule(moduleId) {
   $(`#${moduleId}`).parents('.br-tree-dir').first()
     .addClass('br-tree-dir--is-collapsed');
 
-  navState.closedModules.push(moduleId);
+  if(navState.closedModules.indexOf(moduleId) === -1) {
+    navState.closedModules.push(moduleId);
+  }
 }
 
 /**

--- a/core/js/prototype-nav.js
+++ b/core/js/prototype-nav.js
@@ -39,6 +39,11 @@ $prototypeNav
     const indexOfClickedModule = moduleIds.findIndex(e => e === $(this).text());
     moduleIds = moduleIds.splice(0, indexOfClickedModule + 1);
 
+    // Replace space by -
+    moduleIds = moduleIds.map((moduleId) => {
+      return moduleId.split(" ").join("-")
+    })
+
     $(this).attr('id', moduleIds.join('-'));
   });
 

--- a/core/js/prototype-nav.js
+++ b/core/js/prototype-nav.js
@@ -30,14 +30,11 @@ $prototypeNav
   .each(function () {
     let moduleIds = $(this)
       .parentsUntil('.br-bordered-list')
-      .find('.br-tree-dir-title')
+      .children('.br-tree-dir-title')
       .map(function () {
         return $(this).text();
       })
       .get();
-
-    const indexOfClickedModule = moduleIds.findIndex(e => e === $(this).text());
-    moduleIds = moduleIds.splice(0, indexOfClickedModule + 1);
 
     // Replace space by -
     moduleIds = moduleIds.map((moduleId) => {


### PR DESCRIPTION
I just reverted https://github.com/usebedrock/bedrock/pull/154/commits/f355aaadda24785c3ddea7a101ea7e1731c902c0 for now

- This fixes the problem of the random module id getting reassigned on each page refresh and causing the thing to consider the module as new entry each time

- From my understanding, this will work unless two modules have the same name, which is I think the issue you were trying to fix in the first place here : #147 

My question to you is: 

- How can two modules have the same name as we can't create two folder with the same name in the template folder ? I think I remember we can rename a module with a _doc.md file, but I can't find / remember how to do it ?

- Depending on your answer above, I think we could take the actual filesystem folder name as unique id for modules, that would work as we can't create two folder with the same name , that is guaranteed by the OS.