### PR TITLE
Leverage npm scripts instead of requiring gulp to be installed globally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@ For the full documentation, please check out [the Bedrock website](https://bedro
 ## Basic installation & first run
 
 * First, make sure you have Node 8.3 or later installed. You can find the latest version of Node at [Nodejs.org](https://nodejs.org/en/).
-* You need to have `gulp` installed globally to use Bedrock. `npm install -g gulp`.
 * Install the project's dependencies:
   * `npm install`
-* Run `gulp` to start your project.
+* Run `npm start` to start your project.
 
 ## Major commands
 
-* `gulp`: runs the prototype
-* `gulp build`: create a build (which ends up in the `dist` folder) that can be deployed to a server
+* `npm start`: runs the prototype
+* `npm run build`: create a build (which ends up in the `dist` folder) that can be deployed to a server
 
 ## Upgrading bedrock
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Static site generator to easily make HTML prototypes",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "gulp",
+    "build": "gulp build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi there! I was checking out Bedrock and it struck me that having gulp installed globally is required to get it to work. This PR removes that dependency and might make a little bit easier for people to get going with Bedrock. I've tested this locally on node 8.3 and it works, but maybe give it another spin to be sure! Feel free to decline if there's another reason for having gulp installed globally. 

Cheers!

Jelle