### PR TITLE
Add ability to append footer to component docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ content/scss/settings/_icon-font.scss
 compiled
 tmp
 .bedrock-tmp
+.idea

--- a/content/templates/_components/c-example-2/_docs-footer.md
+++ b/content/templates/_components/c-example-2/_docs-footer.md
@@ -1,0 +1,6 @@
+---
+title: Footer Content
+containsCustom: true
+---
+
+This is the footer

--- a/core/discovery/components.js
+++ b/core/discovery/components.js
@@ -111,6 +111,18 @@ function discover() {
     }
 
     componentGroups[groupId].components.push(componentData);
+
+    try {
+      const docsPath = path.join(TEMPLATES_BASE_DIRECTORY, groupId, '_docs-footer.md');
+      const docsContent = fs.readFileSync(docsPath, 'utf8');
+      const parsedDocs = frontMatter(docsContent);
+
+      parsedDocs.body = marked(parsedDocs.body);
+      componentGroups[groupId].docsFooter = parsedDocs;
+    } catch (err) {
+
+    }
+
   }
 
   return {

--- a/core/templates/styleguide/component-group.pug
+++ b/core/templates/styleguide/component-group.pug
@@ -23,3 +23,11 @@ block content
 
     each component in componentGroup.components
         +sample(component)
+
+    if componentGroup.docsFooter
+        .br-componentgroup-footer-wrapper
+            if componentGroup.docsFooter.attributes
+                h1.br-componentgroup-footer(class=styleguideComponentGroupHeaderClass)= componentGroup.docsFooter.attributes.title || ""
+
+            .br-content(class=styleguideRichContentClass)
+                != componentGroup.docsFooter.body


### PR DESCRIPTION
Addresses issue #350 

I think this is what you were describing. Any `_components` template directory which contains a file called `_docs-footer.md` will have the content appended to the bottom of the page. I've reused the header matter from the `_docs.md` file which may or may not be suitable for your needs.

/cc @Wolfr 