### PR TITLE
Use the current working directory's config file.

### DIFF
--- a/core/discovery/config.js
+++ b/core/discovery/config.js
@@ -1,9 +1,12 @@
+const path = require('path');
+
 const defaultConfig = require('./default-config');
 
 let config = {...defaultConfig};
 
 try {
-  const projectConfig = require('../../bedrock.config');
+  const projectConfigPath = path.join(process.cwd(), 'bedrock.config');
+  const projectConfig = require(projectConfigPath);
   config = {...config, ...projectConfig};
 } catch (err) {
   console.log(err);
@@ -13,7 +16,8 @@ try {
 
 if (process.env.NODE_ENV == "production") {
   try {
-    const projectConfig = require('../../bedrock.config.prod');
+    const projectConfigPath = path.join(process.cwd(), 'bedrock.config.prod');
+    const projectConfig = require(projectConfigPath);
     config = {...config, ...projectConfig};
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
Instead of loading the configuration using a relative path from
core/, load it from the current working directory.

This means that a Bedrock command should be called necessarily from a
project root directory (where the config is supposed to live), but I
guess this was already the case when using commands defined in the
Gulpfile or in the package.json file.

In other words, this change shouldn't have an impact on existing
installs, but paves the road to allow calling Bedrock from projects that
don't have the full source code of Bedrock within their own directory,
and provide their own configuration files.

See https://github.com/usebedrock/bedrock/issues/320 for details.