### PR TITLE
Make the styleguide URL configurable.

### DIFF
--- a/bedrock.config.js
+++ b/bedrock.config.js
@@ -17,6 +17,7 @@ module.exports = {
     purge: false
   },
   styleguide: {
+    url: '/styleguide',
     search: true,
     colors: './content/scss/_colors.scss',
     categoryOrder: [

--- a/core/discovery/default-config.js
+++ b/core/discovery/default-config.js
@@ -27,6 +27,7 @@ const defaultConfig = {
    *  determines whether the styleguide gets generated
    */
   styleguide: {
+    url: '/styleguide',
     /**
      *  search [boolean]
      *  Feature flag for search feature

--- a/core/paths.js
+++ b/core/paths.js
@@ -83,8 +83,8 @@ module.exports = {
     modules: path.join(compiledPath, 'modules/'),
     js: path.join(compiledPath, 'js/'),
     css: path.join(compiledPath, 'css/'),
-    styleguide: path.join(compiledPath, 'styleguide/'),
-    docs: path.join(compiledPath, 'styleguide/docs/'),
+    styleguide: path.join(compiledPath, config.styleguide.url),
+    docs: path.join(compiledPath, config.styleguide.url+'/docs/'),
     assets: {
       images: path.join(compiledPath, 'images/'),
       fonts: path.join(compiledPath, 'fonts/'),
@@ -100,8 +100,8 @@ module.exports = {
       mainPath: path.join(distPath, 'css/'),
       allFiles: path.join(distPath, 'css/**/*.css'),
     },
-    styleguide: path.join(distPath, 'styleguide/'),
-    docs: path.join(distPath, 'styleguide/docs/'),
+    styleguide: path.join(distPath, config.styleguide.url),
+    docs: path.join(distPath, config.styleguide.url+'/docs/'),
     assets: {
       images: path.join(distPath, 'images/'),
       fonts: path.join(distPath, 'fonts/'),

--- a/core/tasks/server.js
+++ b/core/tasks/server.js
@@ -45,13 +45,13 @@ function renderView(req, res, viewName, customLocals) {
 }
 
 module.exports = function (done) {
-  app.get('/styleguide', function (req, res) {
+  app.get(config.styleguide.url, function (req, res) {
     renderView(req, res, 'styleguide/index', {
       pathname: 'styleguide/index'
     });
   });
 
-  app.get('/styleguide/docs/:doc', function (req, res) {
+  app.get(config.styleguide.url+'/docs/:doc', function (req, res) {
     const docFilename = req.params.doc.replace('.html', '');
     const doc = _.find(docs.discover().allDocs, doc => doc.attributes.filename === docFilename);
 
@@ -61,7 +61,7 @@ module.exports = function (done) {
     });
   });
 
-  app.get('/styleguide/:group', function (req, res) {
+  app.get(config.styleguide.url+'/:group', function (req, res) {
     const componentGroups = components.discover();
     const componentGroup = req.params.group.replace('.html', '');
 

--- a/core/tasks/templates.js
+++ b/core/tasks/templates.js
@@ -28,9 +28,10 @@ function getDefaultLocals() {
 
 module.exports = {
   clean(done) {
-    del(['./dist/**.html', './dist/modules', './dist/styleguide']).then(function () {
-      done();
-    });
+    del(['./dist/**.html', './dist/modules', './dist'+config.styleguide.url])
+      .then(function () {
+        done();
+      });
   },
   compile: {
     styleguide(done) {

--- a/core/templates/includes/styleguide-nav.pug
+++ b/core/templates/includes/styleguide-nav.pug
@@ -7,8 +7,8 @@
                 .br-docs-category-list-wrapper(class=styleguideNavListWrapperClass)
                     ul(class=styleguideNavListClass)
                         each doc in docs.byCategory[docsCategoryName]
-                            li(class=styleguideNavListItemClass+' '+`${ "styleguide/docs/" + doc.attributes.filename == pathname ? styleguideNavListItemActiveClass : "" }`)
-                                a(href=`/styleguide/docs/${doc.attributes.filename}.html` class=styleguideNavListItemLinkClass+' '+`${ "styleguide/docs/" + doc.attributes.filename == pathname ? styleguideNavListItemLinkActiveClass : "" }`)
+                            li(class=styleguideNavListItemClass+' '+`${ config.styleguide.url+'/docs/' + doc.attributes.filename == pathname ? styleguideNavListItemActiveClass : "" }`)
+                                a(href=config.styleguide.url+`/docs/${doc.attributes.filename}.html` class=styleguideNavListItemLinkClass+' '+`${ config.styleguide.url+'/docs/' + doc.attributes.filename == pathname ? styleguideNavListItemLinkActiveClass : "" }`)
                                     | #{doc.attributes.title}
         if docsCategoryName === 'Components' && Object.keys(components.byCategory).length > 0
             each category, categoryName in components.byCategory
@@ -21,8 +21,8 @@
                         ul(class=styleguideNavListClass)
                             each group in category
                                 - var groupName = group.docs ? group.docs.attributes.title || group.group.id : group.group.id
-                                li(class=styleguideNavListItemClass+' '+`${ "styleguide/" + group.group.id == pathname ? styleguideNavListItemActiveClass : "" }`)
-                                    a(href=`/styleguide/${group.group.id}.html` class=styleguideNavListItemLinkClass+' '+`${ ("styleguide/" + group.group.id) == pathname ? styleguideNavListItemLinkActiveClass : "" }`)
+                                li(class=styleguideNavListItemClass+' '+`${ config.styleguide.url + '/' + group.group.id == pathname ? styleguideNavListItemActiveClass : "" }`)
+                                    a(href=config.styleguide.url+`/${group.group.id}.html` class=styleguideNavListItemLinkClass+' '+`${ (config.styleguide.url + '/' + group.group.id) == pathname ? styleguideNavListItemLinkActiveClass : "" }`)
                                         |  #{groupName}
                                         if group.docs.attributes.containsCustom
                                             .br-docs-category-marker-custom

--- a/core/templates/mixins/render-page-tree.pug
+++ b/core/templates/mixins/render-page-tree.pug
@@ -24,7 +24,7 @@ mixin renderDirectory(entry)
 mixin renderPageTree
     ul.br-bordered-list
         if config.styleguide
-            li: a(href="/styleguide") Styleguide
+            li: a(href=config.styleguide.url) Styleguide
         each entry in pages
             if entry.type === 'directory'
                 +renderDirectory(entry)


### PR DESCRIPTION
@Wolfr This is a PR to add the styleguide URL configuration thing you added to https://github.com/smartcoop/design/. This is required if we want to make Bedrock a standalone program that can be used with `smartcoop/design` (where such modified code should disappear).