### PR TITLE
Configurable styleguide templates

### DIFF
--- a/bedrock.config.js
+++ b/bedrock.config.js
@@ -20,6 +20,7 @@ module.exports = {
     title: 'Styleguide',
     url: '/styleguide',
     homepage: '/styleguide/docs/introduction.html',
+    overrideStyleguideTemplates: false,
     search: true,
     colors: './content/scss/_colors.scss',
     categoryOrder: [

--- a/core/discovery/default-config.js
+++ b/core/discovery/default-config.js
@@ -32,6 +32,12 @@ const defaultConfig = {
     url: '/styleguide',
     homepage: '/styleguide/docs/introduction.html',
     /**
+     *  overrideStyleguideTemplates [boolean]
+     *  Make Bedrock use the current directory's styleguide
+     *  templates instead of Bedrock's core styleguide templates.
+    */
+    overrideStyleguideTemplates: false,
+    /**
      *  search [boolean]
      *  Feature flag for search feature
     */

--- a/core/paths.js
+++ b/core/paths.js
@@ -6,8 +6,14 @@ const config = require('./discovery/config');
 
 const contentPath = 'content/';
 const corePath = 'core/';
+const absoluteCorePath = __dirname;
 const compiledPath = 'tmp/';
 const distPath = 'dist/';
+
+const styleguideTemplatesPath =
+  config.styleguide.overrideStyleguideTemplates
+  ? path.join(contentPath, 'templates/_styleguide')
+  : path.join(absoluteCorePath, 'templates/styleguide');
 
 module.exports = {
   content: {
@@ -70,10 +76,10 @@ module.exports = {
     },
     templates: {
       styleguide: {
-        index: path.join(corePath, 'templates/styleguide/index.pug'),
-        doc: path.join(corePath, 'templates/styleguide/doc.pug'),
-        colors: path.join(corePath, 'templates/styleguide/colors.pug'),
-        componentGroup: path.join(corePath, 'templates/styleguide/component-group.pug')
+        index: path.join(styleguideTemplatesPath, 'index.pug'),
+        doc: path.join(styleguideTemplatesPath, 'doc.pug'),
+        colors: path.join(styleguideTemplatesPath, 'colors.pug'),
+        componentGroup: path.join(styleguideTemplatesPath, 'component-group.pug')
       }
     }
   },


### PR DESCRIPTION
This allow the templates for the styleguide to live in `content/` instead of `core/`.

I guess this doesn't work with the dev server yet.